### PR TITLE
Issue 61

### DIFF
--- a/src/components/TimeCounter.vue
+++ b/src/components/TimeCounter.vue
@@ -4,14 +4,20 @@
       <v-col cols="12" class="pa-0">
         <div class="time-wrapper">
           <div class="time">
-            <span class="time-title">{{ $tc("caption.elapsed_time", 1) }}</span>
-            <span class="time-value" color="primary">{{ elapsedTime }}</span>
+            <span class="time-title" :style="{ color: currentTheme.secondary }">
+              {{ $tc("caption.elapsed_time", 1) }}
+            </span>
+            <span class="time-value" :style="{ color: currentTheme.secondary }">
+              {{ elapsedTime }}
+            </span>
           </div>
           <div class="time">
-            <span class="time-title">{{ $tc("remaining_time", 1) }}</span>
+            <span class="time-title" :style="{ color: currentTheme.secondary }">
+              {{ $tc("caption.remaining_time", 1) }}
+            </span>
             <span
               :class="`time-value ${this.$store.state.status}`"
-              color="primary"
+              :style="{ color: currentTheme.secondary }"
               >{{ remainingTime }}</span
             >
           </div>
@@ -41,6 +47,13 @@ export default {
       date.setSeconds(timer);
       const result = date.toISOString().substr(11, 8);
       return result;
+    },
+    currentTheme() {
+      if (this.$vuetify.theme.dark) {
+        return this.$vuetify.theme.themes.dark;
+      } else {
+        return this.$vuetify.theme.themes.light;
+      }
     },
     remainingTime() {
       const timer = this.$store.state.duration;

--- a/src/components/TimelineWrapper.vue
+++ b/src/components/TimelineWrapper.vue
@@ -735,7 +735,7 @@
       <v-col cols="12" class="text-center">
         <v-btn
           plain
-          color="primary"
+          :style="{ color: currentTheme.secondary }"
           class="text-capitalize"
           @click="uploadEvidence"
         >

--- a/src/components/WorkspaceWrapper.vue
+++ b/src/components/WorkspaceWrapper.vue
@@ -2,7 +2,11 @@
   <v-container class="workspace">
     <div class="tab-bar">
       <v-tabs :height="26" centered hide-slider>
-        <v-tab class="timeline-tab" @click="currentTab = 'timeline'">
+        <v-tab
+          class="timeline-tab"
+          @click="currentTab = 'timeline'"
+          :style="{ color: currentTheme.secondary }"
+        >
           Timeline
         </v-tab>
         <v-tab class="notes-tab" @click="currentTab = 'notes'"> Notes </v-tab>
@@ -35,6 +39,15 @@ import TimelineWrapper from "./TimelineWrapper.vue";
 
 export default {
   name: "WorkspaceWrapper",
+  computed: {
+    currentTheme() {
+      if (this.$vuetify.theme.dark) {
+        return this.$vuetify.theme.themes.dark;
+      } else {
+        return this.$vuetify.theme.themes.light;
+      }
+    },
+  },
   components: {
     NotesWrapper,
     TimelineWrapper,

--- a/src/components/dialogs/NoteDialog.vue
+++ b/src/components/dialogs/NoteDialog.vue
@@ -71,7 +71,7 @@
             <v-col cols="auto" class="pl-0 d-flex align-end">
               <v-btn
                 plain
-                :color="currentTheme.primary"
+                :color="currentTheme.secondary"
                 class="text-capitalize px-0 btn"
                 @click="handleClear"
               >

--- a/src/components/settings/ConfigCheckListTab.vue
+++ b/src/components/settings/ConfigCheckListTab.vue
@@ -6,10 +6,18 @@
     </p>
     <div class="tab-bar">
       <v-tabs :height="26" hide-slider>
-        <v-tab @click="tab = 'pre'" class="text-capitalize">
+        <v-tab
+          @click="tab = 'pre'"
+          class="text-capitalize"
+          :style="{ color: currentTheme.secondary }"
+        >
           {{ $tc("caption.pre_session", 1) }}
         </v-tab>
-        <v-tab @click="tab = 'post'" class="text-capitalize">
+        <v-tab
+          @click="tab = 'post'"
+          class="text-capitalize"
+          :style="{ color: currentTheme.secondary }"
+        >
           {{ $tc("caption.post_session", 1) }}
         </v-tab>
       </v-tabs>
@@ -52,7 +60,11 @@
             </div>
           </div>
           <div class="footer">
-            <button class="link" @click="addTask">
+            <button
+              class="link"
+              @click="addTask"
+              :style="{ color: currentTheme.secondary }"
+            >
               {{ $tc("caption.add_another_task", 1) }}
             </button>
           </div>
@@ -161,7 +173,15 @@ export default {
       tab: "pre",
     };
   },
-  computed: {},
+  computed: {
+    currentTheme() {
+      if (this.$vuetify.theme.dark) {
+        return this.$vuetify.theme.themes.dark;
+      } else {
+        return this.$vuetify.theme.themes.light;
+      }
+    },
+  },
   methods: {
     fetchData: function () {
       this.preTaskList = this.config.checklist.presession.tasks;

--- a/src/components/settings/ConnectionsTab.vue
+++ b/src/components/settings/ConnectionsTab.vue
@@ -8,7 +8,7 @@
         <a
           class="jira-link"
           @click="signinTestRail"
-          :style="{ color: currentTheme.primary }"
+          :style="{ color: currentTheme.secondary }"
         >
           {{ $t("message.connect_to_testrail") }}
         </a>
@@ -16,7 +16,7 @@
         <a
           class="jira-link"
           @click="signinJira"
-          :style="{ color: currentTheme.primary }"
+          :style="{ color: currentTheme.secondary }"
         >
           {{ $t("message.connect_to_jira") }}
         </a>

--- a/src/components/settings/GeneralTab.vue
+++ b/src/components/settings/GeneralTab.vue
@@ -36,7 +36,11 @@
         </span>
         <p class="note-caption mt-3 mb-0">
           {{ $tc("caption.split_credentials", 1) }}
-          <a href="#" @click="showOAuthDialog">
+          <a
+            href="#"
+            @click="showOAuthDialog"
+            :style="{ color: currentTheme.secondary }"
+          >
             {{ $tc("caption.here", 1) }}
           </a>
         </p>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
[Issue 61](https://github.com/dacoaster/yattie/issues/61)

Fixed hard to read text color when using Dark Mode

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current behavior:

In dark mode the purple text does not change, and on the dark backgrounds this can make it hard to read, especially for the times during

The Elapsed/remaining time , which is almost impossible to see.
image

This purple text can be found in the following locations:

"here" in App Settings > General
"Connect to..." text in App Settings > Connections
"Pre Session" and "Add another task" in App Settings > Session checklists
"Timeline" in a session workspace / after a session
"Upload evidence" in a session workspace / after a session
The elapsed time and "remaining_time" in a running session workspace**
"Clear" in Take a Note (click pencil icon during a session)
Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Font color is readable in dark mode now

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
